### PR TITLE
Update to polymer 3.0.0-pre.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "xo": "0.18.2"
   },
   "dependencies": {
-    "@polymer/polymer": "LasaleFamine/polymer#3.0-preview"
+    "@polymer/polymer": "3.0.0-pre.9"
   }
 }

--- a/src/components/containers/sk-app/index.js
+++ b/src/components/containers/sk-app/index.js
@@ -1,5 +1,5 @@
 
-import {Element as PolymerElement} from '@polymer/polymer/polymer-element';
+import {Element as PolymerElement, html} from '@polymer/polymer/polymer-element';
 
 import css from './style.pcss';
 import template from './template.html';
@@ -24,8 +24,7 @@ export default class SkApp extends PolymerElement {
   }
 
   static get template() {
-    return `
-      <style>${css}</style> ${template}`;
+    return html([`<style>${css}</style> ${template}`]);
   }
 }
 

--- a/src/components/dumbs/sk-button/index.js
+++ b/src/components/dumbs/sk-button/index.js
@@ -1,13 +1,12 @@
 
-import {Element as PolymerElement} from '@polymer/polymer/polymer-element';
+import {Element as PolymerElement, html} from '@polymer/polymer/polymer-element';
 
 import css from './style.pcss';
 import template from './template.html';
 
 export default class SkButton extends PolymerElement {
   static get template() {
-    return `
-      <style>${css}</style> ${template}`;
+    return html([`<style>${css}</style> ${template}`]);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@polymer/polymer@LasaleFamine/polymer#3.0-preview":
-  version "3.0.0-pre.1"
-  resolved "https://codeload.github.com/LasaleFamine/polymer/tar.gz/773ac29294ec8cdd7f310e8ddc7eaf5306bf88ab"
+"@polymer/polymer@3.0.0-pre.8":
+  version "3.0.0-pre.8"
+  resolved "https://registry.yarnpkg.com/@polymer/polymer/-/polymer-3.0.0-pre.8.tgz#075001a300ca9164f4479473b296d46a28d0110e"
   dependencies:
     "@webcomponents/shadycss" "^1.0.0"
     "@webcomponents/webcomponentsjs" "^1.0.0"


### PR DESCRIPTION
Polymer version updated to 3.0.0-pre.9

`template()` methods in Polymer components updated to return an `HTMLTemplateElement` which is required since version 3.0-pre.4 ([Reference](https://www.polymer-project.org/blog/2018-01-18-polymer-3-new-preview))